### PR TITLE
Added friendly platform specific error message when mpg123 is missing

### DIFF
--- a/lib/termit/speech_synthesizer.rb
+++ b/lib/termit/speech_synthesizer.rb
@@ -16,8 +16,19 @@ module Termit
 
     def check_sound_player
       unless system 'which mpg123 > /dev/null'
-        raise "Termit speech synthesis requires mpg123 installed"
+        abort(error_message_for_platform)
       end
+    end
+
+    def error_message_for_platform 
+      message = "Termit speech synthesis requires mpg123 installed."
+      case Gem::Platform.local.os
+      when "darwin"
+        message << "\nPlease run 'brew install mpg123'"
+      when "linux"
+        message << "\nPlease run 'sudo apt-get install mpg123'"
+      end
+      message
     end
   end
 end


### PR DESCRIPTION
This is a patch for issue https://github.com/pawurb/termit/issues/2
