### PR TITLE
Quieter interrupts

### DIFF
--- a/bin/termit
+++ b/bin/termit
@@ -5,7 +5,12 @@ $LOAD_PATH.unshift(File.dirname(__FILE__) + '/../lib') unless $LOAD_PATH.include
 
 require 'termit'
 
+begin
 options = Termit::UserInputParser.new(ARGV).options
 Termit::Main.new(options).translate
+rescue Interrupt
+  STDERR.puts "Exiting due to user request."
+  exit(1)
+end
 
 


### PR DESCRIPTION
We can now press control-c and not get a flood of information.  It may
still be noisy if we interrupt in places that are external to Ruby.
