### PR TITLE
Use range instead of array in language code length validation

### DIFF
--- a/lib/termit/user_input_parser.rb
+++ b/lib/termit/user_input_parser.rb
@@ -38,7 +38,7 @@ module Termit
       raise ArgumentError unless @user_input.is_a? Array
       raise ArgumentError unless @user_input.length > 1
       @user_input.first(2).each do |language_code|
-        raise ArgumentError unless [2,3,4,5].include? language_code.length
+        raise ArgumentError unless (2..5).cover? language_code.length
       end
     end
 


### PR DESCRIPTION
I think it's prettier now